### PR TITLE
Changed: MOB - Decreasing version of swift-tools-version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
### Descrição
Dados os problemas que vem ocorrendo para integração do ABelardo em outros projetos, suspeitamos que uma das razões pode ser a incompatibilidade com a versão do Swift, portanto, é necessário diminuir a versão mínima necessária.

### Alterações
- Configurando a versão do swift-tools-version.